### PR TITLE
Fix fatal compile error in Configuration::getConfigTreeBuilder method signature on Symfony 7

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -9,7 +9,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('twc_maker');
 


### PR DESCRIPTION
Fix fatal compile error in Configuration::getConfigTreeBuilder method signature

The method getConfigTreeBuilder() in Twc\MakerBundle\DependencyInjection\Configuration
now has a return type of TreeBuilder, as required by the ConfigurationInterface
in Symfony\Component\Config\Definition. This change resolves the following error:

CRITICAL  [php] Fatal Compile Error: Declaration of
Twc\MakerBundle\DependencyInjection\Configuration::getConfigTreeBuilder()
must be compatible with
Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder():
Symfony\Component\Config\Definition\Builder\TreeBuilder
